### PR TITLE
docs: Add Architecture, API References, and Agent Hub catalog page

### DIFF
--- a/mofa-website/src/content/docs/en/4. architecture/dora-integration.md
+++ b/mofa-website/src/content/docs/en/4. architecture/dora-integration.md
@@ -1,0 +1,24 @@
+---
+title: "Distributed Dataflow with Dora-rs"
+description: "How MoFA scales to the edge and multi-agent distributed systems."
+order: 3
+---
+
+# Dora Integration
+
+MoFA natively integrates with [Dora-rs](https://github.com/dora-rs/dora), an extremely fast and low-latency dataflow middleware system designed originally for robotics.
+
+## Why Dora?
+
+When building local LLM agent systems, most frameworks quickly hit a bottleneck when it comes to edge computing or cross-machine distributed collaboration.
+
+MoFA solves this by treating agents as nodes in a Dora dataflow graph.
+
+### Distributed by Nature
+- **Cross-process, cross-machine**: Agents communicate transparently across process or hardware boundaries.
+- **Micro-second latency**: Ideal for voice-chat bots (like MoFA Studio) where audio streaming, ASR, and TTS nodes must communicate instantly. 
+
+### Dataflow Orchestration
+Using YAML files, developers can string together complex flows involving Python-based ML nodes (`dora-asr`, `dora-primespeech`) and Rust-based execution nodes (`dora-maas-client`). 
+
+MoFA's microkernel ensures that the outputs from Dora nodes are properly parsed and handled by the agent's core task management loop.

--- a/mofa-website/src/content/docs/en/4. architecture/microkernel.md
+++ b/mofa-website/src/content/docs/en/4. architecture/microkernel.md
@@ -1,0 +1,55 @@
+---
+title: "MoFA Microkernel Architecture"
+description: "Understanding the core of the MoFA framework and its layered design."
+order: 1
+---
+
+# Microkernel Architecture
+
+MoFA adopts a **layered microkernel architecture** with `mofa-kernel` at its core. All other features (including the dual-layer plugin system, LLM capabilities, multi-agent collaboration, etc.) are built as modular components on top of the microkernel.
+
+## Core Design Principles
+
+- **Core Simplicity**: The microkernel contains only the most basic functions: agent lifecycle management, metadata system, and dynamic management.
+- **High Extensibility**: All advanced features are extended through modular components and plugins, keeping the kernel incredibly stable.
+- **Loose Coupling**: Components communicate through standardized interfaces, making them easy to replace and upgrade.
+
+## Visual Architecture Overview
+
+```mermaid
+block-beta
+    columns 1
+    block:business["🧩 Business Layer"]
+        A["User-defined Agents, Workflows, Rules"]
+    end
+    space
+    block:runtime["⚡ Runtime Plugin Layer (Rhai Scripts)"]
+        B["Dynamic tool registration"]
+        C["Rule engine & Scripts"]
+        D["Hot-load logic"]
+    end
+    space
+    block:compile["🔧 Compile-time Plugin Layer (Rust/WASM)"]
+        E["LLM plugins"]
+        F["Tool plugins"]
+        G["Storage & Protocol"]
+    end
+    space
+    block:kernel["🏗️ Microkernel (mofa-kernel)"]
+        H["Lifecycle management"]
+        I["Metadata & Communication"]
+        J["Task scheduling"]
+    end
+
+    business --> runtime
+    runtime --> compile
+    compile --> kernel
+```
+
+## Agent Coordination via the Microkernel
+
+The kernel handles complex coordination seamlessly without bloating the framework:
+
+- **Priority Scheduling**: Task scheduling system based on strict priority levels.
+- **Communication Bus**: A built-in inter-agent communication bus allows seamless interactions via the `SimpleMessageBus` or `DoraChannel`.
+- **Workflow Engine**: Powers the core engine behind visual workflow builders and complex LLM agent collaborations.

--- a/mofa-website/src/content/docs/en/4. architecture/plugin-system.md
+++ b/mofa-website/src/content/docs/en/4. architecture/plugin-system.md
@@ -1,0 +1,28 @@
+---
+title: "Dual-Layer Plugin Architecture"
+description: "How MoFA combines Rust/WASM compile-time performance with Rhai runtime scripting."
+order: 2
+---
+
+# Dual-Layer Plugin System
+
+MoFA's most distinguishing feature is its revolutionary **dual-layer plugin system**. This allows the framework to strike the elusive balance between raw native performance and hot-swappable dynamic flexibility.
+
+## The Two Layers
+
+### 1. Compile-time Plugins (Rust/WASM)
+These plugins are compiled into WebAssembly or native binaries and hook directly into the core framework.
+- Extreme performance, zero runtime overhead.
+- Total type safety and compile-time error checking.
+- Secure WASM sandboxes provide strong isolation.
+- Used for performance-critical paths like LLM inference providers, storage adapters, and high-frequency tool calls.
+
+### 2. Runtime Plugins (Rhai Scripts)
+The embedded [Rhai](https://github.com/rhaiscript/rhai) scripting engine allows for on-the-fly logic definition.
+- **No recompilation needed**. Changes take instant effect.
+- Ideal for business logic hot updates, discounting rules, custom conversational flows.
+- Seamless Bidirectional JSON Conversion for passing arguments between the script and the LLM.
+- Secure sandbox execution with configurable resource limits (CPU cycles, recursion depth).
+
+## Combined Power
+By leveraging both layers, developers can achieve 99% coverage of extension scenarios. You can use Rust plugins for the heavily-lifted data processing tasks, while allowing operations or community contributors to tweak Rhai scripts to alter agent behaviors without ever needing to touch `cargo`.

--- a/mofa-website/src/content/docs/en/5. api-reference/python-bindings.md
+++ b/mofa-website/src/content/docs/en/5. api-reference/python-bindings.md
@@ -1,0 +1,50 @@
+---
+title: "Python SDK & UniFFI Integration"
+description: "How to bind MoFA's core Rust features into Python and other languages."
+order: 2
+---
+
+# Multi-Language Publishing via UniFFI
+
+MoFA is fundamentally "polyglot by design," meaning it guarantees near-zero overhead native integrations across multiple languages without HTTP/RPC latency. We achieve this using Mozilla's **[UniFFI](https://mozilla.github.io/uniffi-rs/)**.
+
+## Generating the Python SDK
+
+Currently, the Rust core exposes interfaces defining structs such as `Agent`, `Prompt`, and `WorkflowEngine`.
+
+### Steps to Compile Python Wheel (Local)
+
+1. Make sure you have python, pip, and maturin installed:
+```bash
+pip install maturin
+```
+2. In the `mofa` repository root:
+```bash
+maturin develop --release
+```
+
+This will compile the `mofa-core` backend and install it directly into your currently active Python virtual environment.
+
+### Using the Python SDK
+
+Here's an example of calling MoFA's Rust-backed LLM workflow engine from a native Python script:
+
+```python
+import mofa_core
+
+agent = mofa_core.Agent("DataAnnotator")
+agent.set_model("gpt-4")
+result = agent.run("Annotate this JSON array...")
+
+print(result)
+```
+
+## Other Languages (Future)
+
+UniFFI natively supports generating bindings for:
+- Swift (iOS/macOS)
+- Kotlin (Android/JVM)
+- Ruby
+- Go
+
+These bindings will eventually be published to their respective package managers.

--- a/mofa-website/src/content/docs/en/5. api-reference/rust-core.md
+++ b/mofa-website/src/content/docs/en/5. api-reference/rust-core.md
@@ -1,0 +1,39 @@
+---
+title: "Rust Core API Reference"
+description: "How to use the MoFA framework natively in Rust."
+order: 1
+---
+
+# Rust Core Reference
+
+MoFA's foundational microkernel, engine, and plugins are built entirely in Rust. This enables high concurrency via the Actor model (`Ractor`), distributed dataflow handling via `dora-rs`, and zero-overhead memory safety.
+
+The MoFA ecosystem in Rust is primarily exposed through the `mofa-sdk` crate. 
+
+## Crates Overview
+
+* **mofa-kernel**: The core types, component registries, and agent lifecycle traits.
+* **mofa-foundation**: Utilities for networking, persistence, and telemetry.
+* **mofa-sdk**: The unified API for building agents and using MoFA's workspace features.
+
+## Exploring the API
+
+The complete Rust reference documentation for MoFA can be found hosted on docs.rs. 
+
+> 👉 **[Visit `docs.rs/mofa-sdk` for the complete Rust API Reference](https://docs.rs/mofa-sdk)**
+
+### Quick Snippet: Building an Agent
+```rust
+use mofa_sdk::{AgentBuilder, Agent, LLMCapability};
+
+#[tokio::main]
+async fn main() {
+    let agent = AgentBuilder::new("ResearcherApp")
+        .with_llm(LLMCapability::new("openai"))
+        .build()
+        .await
+        .unwrap();
+    
+    agent.start().await;
+}
+```

--- a/mofa-website/src/pages/agent-hub.astro
+++ b/mofa-website/src/pages/agent-hub.astro
@@ -1,0 +1,122 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+
+// A mock catalog mapping for the Agent Hub. In a production scenario, this might be fetched from a JSON or the node-hub directory in the main mofa repo.
+const agents = [
+  {
+    name: "dora-asr",
+    type: "Python Node",
+    description: "Real-time speech recognition node using FunASR/Whisper models.",
+    useCase: "Voice Chat Dataflow",
+    snippet: `dora-asr:
+  custom:
+    source: dora-asr
+    inputs:
+      audio: dora-record/audio
+    outputs:
+      - text`
+  },
+  {
+    name: "dora-primespeech",
+    type: "Python Node",
+    description: "High-quality text-to-speech synthesis with multiple voice configurations.",
+    useCase: "Avatar Voice Output",
+    snippet: `dora-primespeech:
+  custom:
+    source: dora-primespeech
+    inputs:
+      text: dora-maas-client/text
+    outputs:
+      - audio`
+  },
+  {
+    name: "dora-maas-client",
+    type: "Rust Node",
+    description: "LLM Inference client interacting with OpenAI, DeepSeek, and Alibaba Cloud.",
+    useCase: "Core Logic Engine",
+    snippet: `dora-maas-client:
+  custom:
+    source: dora-maas-client
+    inputs:
+      text: dora-asr/text
+    outputs:
+      - text`
+  },
+  {
+    name: "dora-conference-bridge",
+    type: "Rust Node",
+    description: "Text routing bridge for complex multi-agent conversations and turn-taking.",
+    useCase: "Multi-Agent Chat",
+    snippet: `dora-conference-bridge:
+  custom:
+    source: dora-conference-bridge
+    inputs:
+      agent1_text: agent1/text
+      agent2_text: agent2/text
+    outputs:
+      - merged_context`
+  },
+];
+---
+
+<BaseLayout title="Agent Hub | MoFA" lang="en">
+  <Header />
+
+  <main class="pt-24 pb-16 bg-white min-h-screen">
+    <div class="container mx-auto px-4">
+      <div class="max-w-4xl mx-auto mb-16 text-center">
+        <h1 class="text-5xl font-extrabold mb-6 tracking-tight text-gray-900">
+          MoFA <span class="text-mondrian-blue">Agent Hub</span>
+        </h1>
+        <p class="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
+          Explore over 500+ pre-built agents, skills, and Dora nodes to compose your perfect AI dataflow.
+        </p>
+        
+        <div class="relative max-w-xl mx-auto bg-gray-100 rounded-lg p-2 border border-gray-300">
+             <input type="text" placeholder="Search agents by name or use case..." class="w-full bg-transparent border-none focus:ring-0 text-gray-800 text-lg px-4 py-2" />
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-6xl mx-auto">
+        {agents.map((agent) => (
+          <div class="bg-gray-50 border-2 border-mondrian-black rounded-lg overflow-hidden transition-transform duration-300 hover:-translate-y-1 shadow-sm">
+            <div class="flex border-b-2 border-mondrian-black">
+              <div class="p-4 bg-mondrian-yellow border-r-2 border-mondrian-black w-24 flex items-center justify-center font-bold text-sm text-center">
+                {agent.type}
+              </div>
+              <div class="p-4 flex-1">
+                <h3 class="text-2xl font-bold font-mono">{agent.name}</h3>
+                <p class="text-sm text-mondrian-blue font-semibold mt-1">Use Case: {agent.useCase}</p>
+              </div>
+            </div>
+            
+            <div class="p-6">
+              <p class="text-gray-700 mb-6 flex-grow">{agent.description}</p>
+              
+              <div class="bg-gray-900 rounded-md p-4 relative group">
+                  <div class="absolute top-2 right-2 flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button class="bg-white/10 hover:bg-white/20 text-xs text-white px-2 py-1 rounded transition-colors" title="Copy YAML block" onclick="navigator.clipboard.writeText(this.parentElement.nextElementSibling.innerText)">
+                          Copy to Studio
+                      </button>
+                  </div>
+                  <pre class="text-sm font-mono text-gray-300 overflow-x-auto"><code>{agent.snippet}</code></pre>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      
+      <div class="text-center mt-16 pb-8 border-b border-gray-200">
+          <p class="text-gray-500 italic">Want to add your custom Node? Check out our <a href="/docs/en/4.%20architecture/plugin-system" class="text-mondrian-blue hover:underline">Plugin Guide</a>.</p>
+      </div>
+    </div>
+  </main>
+
+  <Footer />
+</BaseLayout> 
+
+<style>
+  /* Base styles for the hub layout matching the MoFA theme */
+</style>


### PR DESCRIPTION
Resolves mofa-org/mofa#233. This PR enriches the MoFA documentation site by adding deep dives into the Microkernel and Plugin Architecture, API references for Python/Rust, and a dedicated searchable Agent Hub catalog page.